### PR TITLE
fix: add privacy page route rewrite (fixes #4)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "rewrites": [
+    {
+      "source": "/privacy",
+      "destination": "/privacy.html"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
Fixes #4 - Privacy page returning 404.

## Problem
The privacy page exists at `/privacy.html` but accessing `/privacy` returned a 404 because there was no rewrite rule in Vercel.

## Solution
Added a rewrite rule in `vercel.json` to route `/privacy` to `/privacy.html`.

## Testing
After deploying, `/privacy` should correctly serve the privacy policy page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/n3wth/pull/8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
