### PR TITLE
fix: align canonical URL and sitemap to primary domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Oliver Newth - AI Product Leader | newth.ai</title>
+    <title>Oliver Newth - AI Product Leader | n3wth.com</title>
     <meta name="description" content="Product strategy for AI at billion-user scale. Previously Director of Product at Covariant (Amazon acquisition), Lead PM at Meta, Senior PM at Microsoft." />
     <meta name="author" content="Oliver Newth" />
 
     <!-- Canonical -->
-    <link rel="canonical" href="https://newth.ai/" />
+    <link rel="canonical" href="https://n3wth.com/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Oliver Newth - AI Product Leader" />
     <meta property="og:description" content="Product strategy for AI at billion-user scale. Previously Director of Product at Covariant (Amazon acquisition), Lead PM at Meta, Senior PM at Microsoft." />
-    <meta property="og:url" content="https://newth.ai/" />
-    <meta property="og:image" content="https://newth.ai/og-image.png" />
+    <meta property="og:url" content="https://n3wth.com/" />
+    <meta property="og:image" content="https://n3wth.com/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@olivernewth" />
     <meta name="twitter:creator" content="@olivernewth" />
-    <meta name="twitter:image" content="https://newth.ai/og-image.png" />
+    <meta name="twitter:image" content="https://n3wth.com/og-image.png" />
 
     <!-- Theme -->
     <meta name="theme-color" content="#0a0a0f" />
@@ -35,7 +35,7 @@
       "@context": "https://schema.org",
       "@type": "Person",
       "name": "Oliver Newth",
-      "url": "https://newth.ai",
+      "url": "https://n3wth.com",
       "jobTitle": "AI Product Leader",
       "worksFor": {
         "@type": "Organization",

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Privacy Policy | Oliver Newth - newth.ai</title>
-    <meta name="description" content="Privacy policy for newth.ai - Oliver Newth's personal website." />
+    <title>Privacy Policy | Oliver Newth - n3wth.com</title>
+    <meta name="description" content="Privacy policy for n3wth.com - Oliver Newth's personal website." />
     <meta name="robots" content="noindex" />
-    <link rel="canonical" href="https://newth.ai/privacy" />
+    <link rel="canonical" href="https://n3wth.com/privacy" />
     <meta name="theme-color" content="#0a0a0f" />
     <style>
       :root {
@@ -37,12 +37,12 @@
     </style>
   </head>
   <body>
-    <a href="/" class="back">&larr; Back to newth.ai</a>
+    <a href="/" class="back">&larr; Back to n3wth.com</a>
     <h1>Privacy Policy</h1>
     <p class="updated">Last updated: February 2026</p>
 
     <h2>Overview</h2>
-    <p>This is Oliver Newth's personal portfolio website. This policy describes how information is collected and used on newth.ai.</p>
+    <p>This is Oliver Newth's personal portfolio website. This policy describes how information is collected and used on n3wth.com.</p>
 
     <h2>Information Collection</h2>
     <p>This website does not collect personal information directly. The site does not use cookies for tracking, does not require user accounts, and does not store any personal data.</p>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://newth.ai/sitemap.xml
+Sitemap: https://n3wth.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://newth.ai/</loc>
+    <loc>https://n3wth.com/</loc>
     <lastmod>2026-01-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
Fixes #7

## Summary
Updated all SEO-related URLs from `newth.ai` to `n3wth.com` to align with the primary domain.

## Changes
- **index.html**: Updated canonical URL, OG URL, OG image, Twitter image, and schema.org URL
- **public/robots.txt**: Updated sitemap reference
- **public/sitemap.xml**: Updated URL location
- **public/privacy.html**: Updated canonical URL, title, description, and back link

## Rationale
The Footer navigation and all subdomains (skills.n3wth.com, ui.n3wth.com, garden.n3wth.com) use n3wth.com as the primary domain. This PR aligns SEO metadata to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/n3wth/pull/9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
