### PR TITLE
feat: add business outcomes placeholders to case studies (closes #32)

### DIFF
--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -207,6 +207,35 @@ export function Experience() {
                 {exp.description}
               </p>
 
+              {(exp.businessContext || exp.decision || exp.businessOutcome || exp.strategicLesson) && (
+                <div className="mb-6 space-y-4 border-l border-white/10 pl-4 py-1">
+                  {exp.businessContext && (
+                    <div>
+                      <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Context</span>
+                      <p className="text-sm text-white/70 leading-relaxed">{exp.businessContext}</p>
+                    </div>
+                  )}
+                  {exp.decision && (
+                    <div>
+                      <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Decision</span>
+                      <p className="text-sm text-white/70 leading-relaxed">{exp.decision}</p>
+                    </div>
+                  )}
+                  {exp.businessOutcome && (
+                    <div>
+                      <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Outcome</span>
+                      <p className="text-sm text-white/70 leading-relaxed">{exp.businessOutcome}</p>
+                    </div>
+                  )}
+                  {exp.strategicLesson && (
+                    <div>
+                      <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Strategic Lesson</span>
+                      <p className="text-sm text-white/70 leading-relaxed italic">{exp.strategicLesson}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+
               <div className="flex flex-wrap gap-x-3 gap-y-1">
                 {exp.tech.map((t, i) => (
                   <span
@@ -279,6 +308,35 @@ export function Experience() {
                 >
                   {exp.description}
                 </p>
+
+                {(exp.businessContext || exp.decision || exp.businessOutcome || exp.strategicLesson) && (
+                  <div data-detail className="mb-8 space-y-5 border-l border-white/10 pl-6 py-1 max-w-xl">
+                    {exp.businessContext && (
+                      <div>
+                        <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Context</span>
+                        <p className="text-base text-white/70 leading-relaxed">{exp.businessContext}</p>
+                      </div>
+                    )}
+                    {exp.decision && (
+                      <div>
+                        <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Decision</span>
+                        <p className="text-base text-white/70 leading-relaxed">{exp.decision}</p>
+                      </div>
+                    )}
+                    {exp.businessOutcome && (
+                      <div>
+                        <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Outcome</span>
+                        <p className="text-base text-white/70 leading-relaxed">{exp.businessOutcome}</p>
+                      </div>
+                    )}
+                    {exp.strategicLesson && (
+                      <div>
+                        <span className="block font-mono text-[10px] uppercase tracking-widest text-white/40 mb-1">Strategic Lesson</span>
+                        <p className="text-base text-white/70 leading-relaxed italic">{exp.strategicLesson}</p>
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 <div data-detail className="flex flex-wrap gap-x-4 gap-y-2">
                   {exp.tech.map((t, i) => (

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -38,6 +38,10 @@ export interface Experience {
   description: string
   tech: string[]
   metric?: Metric
+  businessContext?: string
+  decision?: string
+  businessOutcome?: string
+  strategicLesson?: string
 }
 
 export const experiences: Experience[] = [
@@ -49,6 +53,10 @@ export const experiences: Experience[] = [
     description: 'Shipping Gemini-powered products across Google\'s GenAI platform. Working at the intersection of Gemini, PaLM 2, and Imagen models with DeepMind collaboration. Google I/O 2025 speaker on responsible AI deployment in production.',
     tech: ['GenAI', 'Trust & Safety', 'Responsible AI', 'Large Language Models'],
     metric: { value: 'I/O 2025', label: 'Speaker' },
+    businessContext: '[OLIVER: 1 sentence on the business state before]',
+    decision: '[OLIVER: 1-2 sentences on the call Oliver made + trade-offs]',
+    businessOutcome: '[OLIVER: revenue / cost / retention numbers (real, not hand-wavy)]',
+    strategicLesson: '[OLIVER: 1 sentence on what this says about Oliver as a leader]',
   },
   {
     id: 'covariant',
@@ -58,6 +66,10 @@ export const experiences: Experience[] = [
     description: 'AI that touches the physical world. Took computer vision from research demos to warehouse floors running 24/7 across 50+ enterprise deployments, then navigated the company through Amazon\'s acquisition.',
     tech: ['Computer Vision', 'Robotics', 'Enterprise AI', 'M&A'],
     metric: { value: '50+', label: 'Enterprise deployments' },
+    businessContext: '[OLIVER: 1 sentence on the business state before]',
+    decision: '[OLIVER: 1-2 sentences on the call Oliver made + trade-offs]',
+    businessOutcome: '[OLIVER: revenue / cost / retention numbers (real, not hand-wavy)]',
+    strategicLesson: '[OLIVER: 1 sentence on what this says about Oliver as a leader]',
   },
   {
     id: 'meta',
@@ -67,6 +79,10 @@ export const experiences: Experience[] = [
     description: 'Real-time infrastructure at Instagram speed. Launched video calling to 750 million daily users—learning that at this scale, latency is a feature and reliability is the product.',
     tech: ['Real-time Systems', 'Consumer Social', 'Scale Infrastructure'],
     metric: { value: '750M', label: 'Daily active users' },
+    businessContext: '[OLIVER: 1 sentence on the business state before]',
+    decision: '[OLIVER: 1-2 sentences on the call Oliver made + trade-offs]',
+    businessOutcome: '[OLIVER: revenue / cost / retention numbers (real, not hand-wavy)]',
+    strategicLesson: '[OLIVER: 1 sentence on what this says about Oliver as a leader]',
   },
   {
     id: 'microsoft',
@@ -76,6 +92,10 @@ export const experiences: Experience[] = [
     description: 'Where I learned that developer platforms are trust products. Built Azure Cognitive Services APIs used by millions of developers and established the playbook for enterprise AI adoption.',
     tech: ['Developer Platforms', 'Cognitive Services', 'Enterprise AI'],
     metric: { value: '1M+', label: 'API calls per day' },
+    businessContext: '[OLIVER: 1 sentence on the business state before]',
+    decision: '[OLIVER: 1-2 sentences on the call Oliver made + trade-offs]',
+    businessOutcome: '[OLIVER: revenue / cost / retention numbers (real, not hand-wavy)]',
+    strategicLesson: '[OLIVER: 1 sentence on what this says about Oliver as a leader]',
   },
 ]
 


### PR DESCRIPTION
## Summary
This PR adds the structural scaffolding for business outcomes in the experience/case studies section, as requested in #32.

### Changes
- Data Schema: Updated Experience interface in src/data/content.ts to include businessContext, decision, businessOutcome, and strategicLesson.
- Content: Added [OLIVER:] placeholders for all 4 experience entries (Google, Covariant, Meta, Microsoft).
- UI: Updated Experience.tsx component to render these new fields in both mobile and desktop views.

### Placeholders Added
The following [OLIVER:] markers were left for Oliver to fill:
- [OLIVER: 1 sentence on the business state before] (x4)
- [OLIVER: 1-2 sentences on the call Oliver made + trade-offs] (x4)
- [OLIVER: revenue / cost / retention numbers (real, not hand-wavy)] (x4)
- [OLIVER: 1 sentence on what this says about Oliver as a leader] (x4)

### Files Touched
- src/data/content.ts: Added fields and placeholder content.
- src/components/sections/Experience.tsx: Added rendering logic for the new fields.

Closes #32

---
_Auto-generated by Fix Agent_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/n3wth/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
