### PR TITLE
fix: remove generic AI gradients and establish flat identity (closes #31)

### DIFF
--- a/src/components/BackgroundElements.tsx
+++ b/src/components/BackgroundElements.tsx
@@ -51,10 +51,10 @@ export function BackgroundElements() {
           <div
             key={`v-${i}`}
             data-grid-line
-            className="absolute top-0 bottom-0 w-px opacity-[0.06]"
+            className="absolute top-0 bottom-0 w-px opacity-[0.04]"
             style={{
               left: `${(i + 1) * 12.5}%`,
-              background: 'linear-gradient(to bottom, transparent, var(--color-grey-700), transparent)',
+              background: 'var(--color-grey-800)',
             }}
           />
         ))}
@@ -67,7 +67,7 @@ export function BackgroundElements() {
         style={{
           top: '10%',
           right: '-10%',
-          background: 'radial-gradient(circle, rgba(255,255,255,0.015) 0%, transparent 70%)',
+          background: 'rgba(255,255,255,0.01)',
           willChange: 'transform',
         }}
       />
@@ -77,7 +77,7 @@ export function BackgroundElements() {
         style={{
           top: '60%',
           left: '-5%',
-          background: 'radial-gradient(circle, rgba(255,255,255,0.01) 0%, transparent 70%)',
+          background: 'rgba(255,255,255,0.005)',
           willChange: 'transform',
         }}
       />
@@ -87,7 +87,7 @@ export function BackgroundElements() {
         style={{
           top: '40%',
           right: '10%',
-          border: '1px solid rgba(255,255,255,0.03)',
+          border: '1px solid rgba(255,255,255,0.02)',
           transform: 'rotate(45deg)',
           willChange: 'transform',
         }}
@@ -99,7 +99,7 @@ export function BackgroundElements() {
         style={{
           top: '20%',
           left: '20%',
-          background: 'linear-gradient(to bottom, transparent, rgba(255,255,255,0.05), transparent)',
+          background: 'rgba(255,255,255,0.03)',
           transform: 'rotate(30deg)',
         }}
       />

--- a/src/components/ParticleField.tsx
+++ b/src/components/ParticleField.tsx
@@ -15,8 +15,8 @@ const ACCENT_COLORS = [
   'rgba(255, 217, 61, 0.6)',  // yellow
   'rgba(167, 139, 250, 0.6)', // purple
 ]
-const DEFAULT_COLOR = 'rgba(255, 255, 255, 0.15)'
-const LINE_COLOR = 'rgba(255, 255, 255, 0.04)'
+const DEFAULT_COLOR = 'rgba(255, 255, 255, 0.1)'
+const LINE_COLOR = 'rgba(255, 255, 255, 0.02)'
 const CONNECTION_DIST = 120
 const CURSOR_RADIUS = 150
 const CURSOR_FORCE = 0.8

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -143,7 +143,7 @@ export function Contact() {
           <h2
             ref={titleRef}
             data-contact-title
-            className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-semibold text-white tracking-tight leading-[1.05] mb-4 sm:mb-6 md:mb-8 text-glow"
+            className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-semibold text-white tracking-tight leading-[1.05] mb-4 sm:mb-6 md:mb-8"
             style={{ perspective: '1000px' }}
           >
             Let's talk

--- a/src/components/sections/Creative.tsx
+++ b/src/components/sections/Creative.tsx
@@ -206,7 +206,7 @@ export function Creative() {
           <div className="mx-auto max-w-6xl px-6 md:px-12">
             <div data-cr-header>
               <p className="label mb-3 sm:mb-4">After hours</p>
-              <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6 text-glow">
+              <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6">
                 I build things that glow
               </h2>
               <p
@@ -240,10 +240,8 @@ export function Creative() {
                     className="absolute -inset-4 sm:-inset-6 md:-inset-8 lg:-inset-12 -z-10 rounded-2xl sm:rounded-3xl"
                     style={{
                       background: inst.lightBg
-                        ? 'radial-gradient(ellipse 120% 100% at 20% 50%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0.3) 50%, transparent 80%)'
-                        : 'radial-gradient(ellipse 120% 100% at 20% 50%, rgba(0,0,0,0.6) 0%, rgba(0,0,0,0.3) 50%, transparent 80%)',
-                      backdropFilter: 'blur(40px)',
-                      WebkitBackdropFilter: 'blur(40px)',
+                        ? 'rgba(255,255,255,0.85)'
+                        : 'rgba(0,0,0,0.75)',
                     }}
                   />
                   <span

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -142,7 +142,7 @@ export function Experience() {
         <div className="mx-auto max-w-6xl px-6 md:px-12">
           <div data-exp-header className="mb-10 sm:mb-16 md:mb-20">
             <p className="label mb-3 sm:mb-4">Experience</p>
-            <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] text-glow">
+            <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1]">
               Building AI products
               <br />
               at billion-user scale
@@ -182,7 +182,7 @@ export function Experience() {
                 </span>
               </div>
 
-              <h3 className="font-display text-3xl font-semibold text-white tracking-tighter leading-[0.9] mb-2 text-glow">
+              <h3 className="font-display text-3xl font-semibold text-white tracking-tighter leading-[0.9] mb-2">
                 {exp.company}
               </h3>
 
@@ -252,7 +252,7 @@ export function Experience() {
 
                 <h3
                   data-company
-                  className="font-display text-[clamp(2rem,8vw,9rem)] font-semibold text-white tracking-tighter leading-[0.9] mb-4 md:mb-6 text-glow"
+                  className="font-display text-[clamp(2rem,8vw,9rem)] font-semibold text-white tracking-tighter leading-[0.9] mb-4 md:mb-6"
                 >
                   {exp.company}
                 </h3>

--- a/src/components/sections/Frameworks.tsx
+++ b/src/components/sections/Frameworks.tsx
@@ -45,7 +45,7 @@ export function Frameworks() {
       <div className="mx-auto max-w-6xl px-6 md:px-12">
         <div data-fw-header className="mb-10 sm:mb-16 md:mb-24">
           <p className="label mb-3 sm:mb-4">After a decade of building</p>
-          <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6 text-glow">
+          <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6">
             Four things I believe
           </h2>
           <p

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -176,7 +176,7 @@ export function Hero() {
         {/* Big name - stacked for visual impact */}
         <h1
           ref={titleRef}
-          className="text-[clamp(2.5rem,10vw,12rem)] font-display font-semibold tracking-tighter leading-[0.85] mb-4 sm:mb-6 md:mb-8 text-white text-glow"
+          className="text-[clamp(2.5rem,10vw,12rem)] font-display font-semibold tracking-tighter leading-[0.85] mb-4 sm:mb-6 md:mb-8 text-white"
           style={{ perspective: '1000px' }}
         >
           Oliver<br />Newth
@@ -185,7 +185,7 @@ export function Hero() {
         {/* The hook - visible by default for LCP, animated only after JS ready */}
         <p
           data-hero-tagline
-          className={`text-base sm:text-lg md:text-2xl lg:text-3xl xl:text-4xl leading-snug max-w-2xl text-white font-display font-medium tracking-tight text-glow-subtle ${animationReady ? 'opacity-0' : 'opacity-100'}`}
+          className={`text-base sm:text-lg md:text-2xl lg:text-3xl xl:text-4xl leading-snug max-w-2xl text-white font-display font-medium tracking-tight ${animationReady ? 'opacity-0' : 'opacity-100'}`}
         >
           AI at Google.<br className="sm:hidden" /> Art in the desert.
         </p>

--- a/src/components/sections/Thinking.tsx
+++ b/src/components/sections/Thinking.tsx
@@ -82,7 +82,7 @@ export function Thinking() {
         {/* Section header */}
         <div data-th-header className="mb-10 sm:mb-16 md:mb-24">
           <p className="label mb-3 sm:mb-4">Thinking</p>
-          <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6 text-glow">
+          <h2 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold text-white tracking-tight leading-[1.1] mb-4 sm:mb-6">
             Where trust meets craft
           </h2>
           <p

--- a/src/index.css
+++ b/src/index.css
@@ -77,11 +77,11 @@
   --color-grey-800: #1d1d1f;
 
   --color-accent: #ffffff;
-  --color-accent-soft: rgba(255, 255, 255, 0.15);
+  --color-accent-soft: rgba(255, 255, 255, 0.1);
 
-  --glass-bg: rgba(255, 255, 255, 0.05);
-  --glass-border: rgba(255, 255, 255, 0.1);
-  --glass-highlight: rgba(255, 255, 255, 0.15);
+  --glass-bg: #0a0a0a;
+  --glass-border: #1d1d1f;
+  --glass-highlight: #2a2a2a;
 
   --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
@@ -105,11 +105,11 @@
   --color-grey-800: #1d1d1f;
 
   --color-accent: #ffffff;
-  --color-accent-soft: rgba(255, 255, 255, 0.15);
+  --color-accent-soft: rgba(255, 255, 255, 0.1);
 
-  --glass-bg: rgba(255, 255, 255, 0.05);
-  --glass-border: rgba(255, 255, 255, 0.1);
-  --glass-highlight: rgba(255, 255, 255, 0.15);
+  --glass-bg: #0a0a0a;
+  --glass-border: #1d1d1f;
+  --glass-highlight: #2a2a2a;
 
   --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
@@ -185,12 +185,11 @@ body {
 
 /* Apple-style subtle text shadow for readability over shapes */
 .text-glow {
-  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.5),
-               0 1px 3px rgba(0, 0, 0, 0.3);
+  text-shadow: none;
 }
 
 .text-glow-subtle {
-  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
+  text-shadow: none;
 }
 
 /* Link hover underline animation */


### PR DESCRIPTION
## Summary
This PR implements phase 1 of the design refresh, removing generic 'AI website' tropes in favor of a flat, typography-driven identity as specified in #31.

### Changes
- **Removed Gradients:** Replaced `bg-gradient-*` and inline `linear-gradient`/`radial-gradient` with solid backgrounds.
- **Removed Glass-morphism:** Replaced translucent `backdrop-blur` stacks with solid `var(--glass-bg)` (#0a0a0a) and defined flat borders.
- **Removed Text Glows:** Stripped `text-shadow` from `.text-glow` and `.text-glow-subtle` classes.
- **Refined Backgrounds:** Simplified the fixed background grid and floating shapes to use subtle solid colors/opacities instead of gradients.
- **Reduced Particle Density:** Lowered particle and line opacity in `ParticleField` for a cleaner look.

### Verification
- Ran `npm run build` successfully.
- Verified all section headers and cards now use flat styling.

Closes #31

---
_Auto-generated by Fix Agent_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/n3wth/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
