### PR TITLE
Fix hero title spacing and restore systems phrase

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -196,7 +196,7 @@ export function Hero() {
           className={`mt-3 sm:mt-6 text-sm sm:text-base md:text-lg lg:text-xl leading-relaxed max-w-xl ${animationReady ? 'opacity-0' : 'opacity-100'}`}
           style={{ color: 'var(--color-grey-300)' }}
         >
-          Shipping AI products to billions of users across Google, Meta, and Microsoft. Google I/O 2025 speaker.
+          Shipping AI products to billions of users across Google, Meta, and Microsoft. Google I/O 2025 speaker. 10+ years bringing AI systems from research to production.
         </p>
 
         {/* Currently signal - forward trajectory */}


### PR DESCRIPTION
Fixes #30. Restores the '10+ years bringing AI systems from research to production' phrase to the hero subtitle, ensuring proper spacing and context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/n3wth/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
