### PR TITLE
Design: staggered entrances, scroll reveals, hover polish, blueprint indices

### DIFF
--- a/src/components/Frame.tsx
+++ b/src/components/Frame.tsx
@@ -23,16 +23,19 @@ export function Rule() {
 }
 
 /**
- * Section header: a quiet sans eyebrow, a large display headline, and an
- * optional lede. Children render an optional geometric mark that diagrams the
- * adjacent concept.
+ * Section header: a quiet sans eyebrow (with optional blueprint index), a
+ * large display headline, and an optional lede. Children render an optional
+ * geometric mark that diagrams the adjacent concept. Parts carry [data-reveal]
+ * so a section-level useReveal container can stagger them in.
  */
 export function SectionHeader({
+  index,
   eyebrow,
   title,
   lede,
   mark,
 }: {
+  index?: string
   eyebrow: string
   title: ReactNode
   lede?: ReactNode
@@ -42,12 +45,21 @@ export function SectionHeader({
     <header className="section-pad pb-8 md:pb-12">
       <div className="flex items-start justify-between gap-6">
         <div className="min-w-0">
-          <p className="eyebrow mb-5">
+          <p className="eyebrow mb-5" data-reveal>
+            {index && (
+              <>
+                <span style={{ color: 'var(--ink-label)' }}>{index}</span>
+                <span className="mx-2.5" style={{ color: 'var(--rail-strong)' }} aria-hidden="true">
+                  /
+                </span>
+              </>
+            )}
             {eyebrow}
           </p>
           <h2
             className="display text-[clamp(1.85rem,3.8vw,3.1rem)] max-w-[18ch]"
             style={{ letterSpacing: '-0.03em', lineHeight: 1 }}
+            data-reveal
           >
             {title}
           </h2>
@@ -55,6 +67,7 @@ export function SectionHeader({
             <p
               className="t-lead mt-6 max-w-xl"
               style={{ color: 'var(--ink-dim)' }}
+              data-reveal
             >
               {lede}
             </p>
@@ -64,6 +77,7 @@ export function SectionHeader({
           <div
             className="hidden sm:block shrink-0"
             style={{ color: 'var(--ink-faint)' }}
+            data-reveal
           >
             {mark}
           </div>

--- a/src/components/sections/AIExplainer.tsx
+++ b/src/components/sections/AIExplainer.tsx
@@ -3,13 +3,16 @@ import { ForkMark } from '../marks'
 import { aiChallenges } from '../../data/ai-challenges'
 import { useAIExplainerState } from '../../hooks/useAIExplainerState'
 import { ChallengeCard } from '../ai-explainer/ChallengeCard'
+import { useReveal } from '../../hooks/useReveal'
 
 export function AIExplainer() {
   const { makeChoice, getChallengeState } = useAIExplainerState()
+  const revealRef = useReveal<HTMLElement>()
 
   return (
-    <section id="ai-explainer" aria-label="Alignment">
+    <section id="ai-explainer" aria-label="Alignment" ref={revealRef}>
       <SectionHeader
+        index="04"
         eyebrow="Alignment"
         title={
           <>

--- a/src/components/sections/Building.tsx
+++ b/src/components/sections/Building.tsx
@@ -3,6 +3,7 @@ import { Github, Star, GitFork } from 'lucide-react'
 import { SectionHeader } from '../Frame'
 import { CubeMark } from '../marks'
 import { projects, type Project } from '../../data/content'
+import { useReveal } from '../../hooks/useReveal'
 
 export interface GitHubStats {
   stars: number | string
@@ -102,9 +103,11 @@ export function ProjectCard({ project }: { project: Project }) {
 }
 
 export function Building() {
+  const revealRef = useReveal<HTMLElement>()
   return (
-    <section id="building" aria-label="Building">
+    <section id="building" aria-label="Building" ref={revealRef}>
       <SectionHeader
+        index="02"
         eyebrow="Open source"
         title="Tools I've shipped"
         lede="Small, focused tools for AI and collaboration — documented, in production, and free to use."
@@ -118,6 +121,7 @@ export function Building() {
               key={project.id}
               className={i === 0 ? 'md:col-span-2' : undefined}
               style={{ background: 'var(--bg)' }}
+              data-reveal
             >
               <ProjectCard project={project} />
             </div>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,28 +1,36 @@
 import { ArrowUpRight } from 'lucide-react'
 import { siteConfig } from '../../data/content'
 import { ArrowMark } from '../marks'
+import { useReveal } from '../../hooks/useReveal'
 
 export function Contact() {
+  const revealRef = useReveal<HTMLElement>()
   return (
     <section
       id="contact"
       aria-label="Contact"
       className="relative min-h-[85vh] flex items-center"
+      ref={revealRef}
     >
       <span className="tick tick-tl" aria-hidden="true" style={{ top: 0, left: -5 }} />
       <div className="section-pad pad-air w-full">
         <div className="flex items-start justify-between gap-6">
           <div className="max-w-3xl">
-            <p className="eyebrow mb-6">
+            <p className="eyebrow mb-6" data-reveal>
+              <span style={{ color: 'var(--ink-label)' }}>06</span>
+              <span className="mx-2.5" style={{ color: 'var(--rail-strong)' }} aria-hidden="true">
+                /
+              </span>
               Get in touch
             </p>
-            <h2 className="display text-[clamp(3rem,12vw,9rem)]">
+            <h2 className="display text-[clamp(3rem,12vw,9rem)]" data-reveal>
               Let's talk
             </h2>
 
             <p
               className="mt-8 text-base md:text-xl leading-relaxed max-w-lg"
               style={{ color: 'var(--ink-dim)' }}
+              data-reveal
             >
               Happy to talk about AI safety, LED art, or grab coffee in San
               Francisco.
@@ -31,6 +39,7 @@ export function Contact() {
             <a
               href={`mailto:${siteConfig.email}`}
               className="btn btn-solid mt-10 group"
+              data-reveal
             >
               {siteConfig.email}
               <ArrowUpRight
@@ -41,7 +50,7 @@ export function Contact() {
               />
             </a>
 
-            <ul className="flex flex-wrap gap-x-8 gap-y-3 mt-12">
+            <ul className="flex flex-wrap gap-x-8 gap-y-3 mt-12" data-reveal>
               <li>
                 <a
                   href={siteConfig.social.github}

--- a/src/components/sections/Creative.tsx
+++ b/src/components/sections/Creative.tsx
@@ -1,6 +1,7 @@
 import { SectionHeader } from '../Frame'
 import { BeamsMark } from '../marks'
 import { installations } from '../../data/content'
+import { useReveal } from '../../hooks/useReveal'
 
 /** "burning-man" -> "Burning man" (sentence case, hyphens to spaces). */
 function sentenceCase(type: string) {
@@ -9,9 +10,11 @@ function sentenceCase(type: string) {
 }
 
 export function Creative() {
+  const revealRef = useReveal<HTMLElement>()
   return (
-    <section id="creative" aria-label="Creative">
+    <section id="creative" aria-label="Creative" ref={revealRef}>
       <SectionHeader
+        index="05"
         eyebrow="After hours"
         title="I build things that glow"
         lede="Large-scale LED installations for Burning Man and public memorials. I spoke at Robot Heart about where art and technology meet."
@@ -24,14 +27,14 @@ export function Creative() {
           style={{ background: 'var(--rail)' }}
         >
           {installations.map((inst) => (
-            <article key={inst.id} className="cell group flex flex-col">
+            <article key={inst.id} className="cell group flex flex-col" data-reveal>
               <div className="relative aspect-[4/3] overflow-hidden" style={{ background: 'var(--bg)' }}>
                 <img
                   src={inst.image}
                   alt={inst.imageAlt}
                   loading="lazy"
                   decoding="async"
-                  className="absolute inset-0 h-full w-full object-cover"
+                  className="cell-img absolute inset-0 h-full w-full object-cover"
                 />
               </div>
 

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -1,15 +1,18 @@
 import { SectionHeader } from '../Frame'
 import { RingsMark } from '../marks'
 import { experiences } from '../../data/content'
+import { useReveal } from '../../hooks/useReveal'
 
 function isReal(v?: string) {
   return !!v && !v.trimStart().startsWith('[OLIVER')
 }
 
 export function Experience() {
+  const revealRef = useReveal<HTMLElement>()
   return (
-    <section id="work" aria-label="Experience">
+    <section id="work" aria-label="Experience" ref={revealRef}>
       <SectionHeader
+        index="01"
         eyebrow="Experience"
         title={
           <>
@@ -35,6 +38,7 @@ export function Experience() {
               key={exp.id}
               className="relative section-pad !py-10 md:!py-14"
               style={{ borderTop: '1px solid var(--rail)' }}
+              data-reveal
             >
               <span className="tick tick-tl" aria-hidden="true" />
               <span className="tick tick-tr" aria-hidden="true" />

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,22 +1,46 @@
+import { useRef } from 'react'
 import { ArrowDown, ArrowRight } from 'lucide-react'
 import { AsciiField } from '../AsciiField'
+import { gsap, useGSAP } from '../../lib/gsap'
 
 export function Hero() {
+  const sectionRef = useRef<HTMLElement>(null)
+
+  useGSAP(
+    () => {
+      // [data-hero-reveal] elements start hidden via CSS gated behind
+      // prefers-reduced-motion: no-preference, so under reduce there is
+      // nothing to animate and nothing left hidden.
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+      gsap.to('[data-hero-reveal]', {
+        opacity: 1,
+        y: 0,
+        duration: 1,
+        ease: 'power3.out',
+        stagger: 0.09,
+        delay: 0.1,
+      })
+    },
+    { scope: sectionRef }
+  )
+
   return (
     <section
       id="top"
+      ref={sectionRef}
       className="relative min-h-[100svh] flex flex-col justify-end overflow-hidden"
     >
       <AsciiField />
 
       <div className="relative z-10 section-pad pad-air !pb-14 md:!pb-20 w-full">
-        <p className="eyebrow mb-6 md:mb-8">
+        <p className="eyebrow mb-6 md:mb-8" data-hero-reveal>
           San Francisco — AI Product Leader
         </p>
 
         <h1
           className="display text-[clamp(2.75rem,11vw,8rem)]"
           style={{ lineHeight: 0.82 }}
+          data-hero-reveal
         >
           Oliver
           <br />
@@ -27,10 +51,11 @@ export function Hero() {
           <p
             className="text-lg md:text-2xl leading-snug display !tracking-tight"
             style={{ letterSpacing: '-0.02em' }}
+            data-hero-reveal
           >
             AI at Google. <span className="accent">Art in the desert.</span>
           </p>
-          <div className="space-y-4 max-w-md">
+          <div className="space-y-4 max-w-md" data-hero-reveal>
             <p className="text-sm md:text-base leading-relaxed" style={{ color: 'var(--ink-dim)' }}>
               I've shipped AI products to billions of users across Google, Meta,
               and Microsoft, and spoke at Google I/O 2025. A decade taking AI
@@ -43,7 +68,7 @@ export function Hero() {
           </div>
         </div>
 
-        <div className="mt-10 md:mt-14 flex flex-wrap items-center gap-4">
+        <div className="mt-10 md:mt-14 flex flex-wrap items-center gap-4" data-hero-reveal>
           <a href="#contact" className="btn btn-solid">
             Get in touch
             <ArrowRight size={16} strokeWidth={1.5} className="btn-arrow" aria-hidden="true" />

--- a/src/components/sections/Thinking.tsx
+++ b/src/components/sections/Thinking.tsx
@@ -1,11 +1,14 @@
 import { SectionHeader } from '../Frame'
 import { NodesMark } from '../marks'
 import { thoughtPieces } from '../../data/thinking'
+import { useReveal } from '../../hooks/useReveal'
 
 export function Thinking() {
+  const revealRef = useReveal<HTMLElement>()
   return (
-    <section id="thinking" aria-label="Thinking">
+    <section id="thinking" aria-label="Thinking" ref={revealRef}>
       <SectionHeader
+        index="03"
         eyebrow="Point of view"
         title="What I believe about production AI"
         lede="Two positions I've arrived at after a decade shipping AI at scale — and the specific, hard-won reasons behind each."
@@ -19,6 +22,7 @@ export function Thinking() {
             key={piece.id}
             className="relative py-10 md:py-14"
             style={{ borderBottom: '1px solid var(--rail)' }}
+            data-reveal
           >
             <div className="grid gap-6 md:grid-cols-[7rem_minmax(0,1fr)] md:gap-10">
               <div className="flex md:flex-col items-baseline md:items-start gap-4 md:gap-3 md:pt-2">

--- a/src/hooks/useReveal.ts
+++ b/src/hooks/useReveal.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react'
+
+const STAGGER_MS = 80
+const SETTLE_MS = 1100
+
+/**
+ * Reveals descendants marked with [data-reveal] as they enter the viewport
+ * by adding `.is-revealed`. The hidden state lives in CSS behind
+ * prefers-reduced-motion: no-preference, so reduced-motion users always see
+ * content immediately. Elements that intersect in the same batch stagger by
+ * STAGGER_MS. Once an entrance settles, the attribute and inline delay are
+ * removed so the reveal transition can't shadow an element's own hover
+ * transitions (e.g. .cell border-color).
+ */
+export function useReveal<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const root = ref.current
+    if (!root) return
+    const els = Array.from(root.querySelectorAll<HTMLElement>('[data-reveal]'))
+    if (els.length === 0) return
+
+    if (
+      typeof IntersectionObserver === 'undefined' ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      els.forEach((el) => el.removeAttribute('data-reveal'))
+      return
+    }
+
+    const timeouts = new Set<number>()
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let batch = 0
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          const el = entry.target as HTMLElement
+          observer.unobserve(el)
+          const delay = batch * STAGGER_MS
+          el.style.transitionDelay = `${delay}ms`
+          el.classList.add('is-revealed')
+          const id = window.setTimeout(() => {
+            el.style.transitionDelay = ''
+            el.removeAttribute('data-reveal')
+            timeouts.delete(id)
+          }, SETTLE_MS + delay)
+          timeouts.add(id)
+          batch += 1
+        }
+      },
+      { rootMargin: '0px 0px -8% 0px' }
+    )
+    els.forEach((el) => observer.observe(el))
+
+    return () => {
+      observer.disconnect()
+      timeouts.forEach((id) => window.clearTimeout(id))
+    }
+  }, [])
+
+  return ref
+}

--- a/src/index.css
+++ b/src/index.css
@@ -194,6 +194,7 @@ body {
   letter-spacing: -0.045em;
   line-height: 0.92;
   color: var(--ink);
+  text-wrap: balance;
 }
 
 .accent { color: var(--accent); font-weight: 600; }
@@ -233,12 +234,14 @@ body {
   letter-spacing: -0.03em;
   line-height: 1;
   color: var(--ink);
+  text-wrap: balance;
 }
 .t-lead {
   font-size: 1.125rem;
   font-weight: 400;
   letter-spacing: -0.01em;
   line-height: 1.55;
+  text-wrap: pretty;
 }
 
 /* ---------- Links ---------- */
@@ -272,6 +275,18 @@ body {
   background: rgba(255, 255, 255, 0.025);
 }
 
+/* ---------- Cell imagery ---------- */
+/* Images inside .cell rest slightly desaturated; hover restores full color
+   with a slow, restrained zoom. Wrapper must clip (overflow hidden). */
+.cell-img {
+  filter: grayscale(30%);
+  transition: filter 0.6s var(--ease), transform 1.1s var(--ease);
+}
+.cell:hover .cell-img {
+  filter: grayscale(0%);
+  transform: scale(1.03);
+}
+
 /* ---------- Buttons ---------- */
 /* Ghost: subtle hover (border→accent-rail, text→ink). Solid: ink fill. */
 .btn {
@@ -302,9 +317,10 @@ body {
 }
 .btn-solid:hover {
   color: var(--bg);
-  background: var(--ink);
-  border-color: var(--ink);
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
 }
+.btn-solid:hover .btn-arrow { color: var(--bg); }
 .btn .btn-arrow { color: var(--ink-dim); transition: color 0.3s var(--ease); }
 .btn:hover .btn-arrow { color: var(--ink); }
 .btn-solid .btn-arrow { color: var(--bg); }
@@ -379,6 +395,26 @@ body {
 /* ---------- Touch targets ---------- */
 @media (pointer: coarse) {
   a, button { min-height: 44px; }
+}
+
+/* ---------- Entrances ---------- */
+/* Hidden states are gated behind no-preference so reduced-motion users and
+   non-JS readers always see content. [data-reveal] is driven by useReveal
+   (IntersectionObserver); [data-hero-reveal] by the Hero GSAP timeline. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-reveal] {
+    opacity: 0;
+    transform: translateY(18px);
+    transition: opacity 0.8s var(--ease), transform 0.8s var(--ease);
+  }
+  [data-reveal].is-revealed {
+    opacity: 1;
+    transform: none;
+  }
+  [data-hero-reveal] {
+    opacity: 0;
+    transform: translateY(26px);
+  }
 }
 
 /* ---------- Reduced motion ---------- */


### PR DESCRIPTION
## What

Applies the recommendations from [Anthropic's frontend-aesthetics cookbook](https://platform.claude.com/cookbook/coding-prompting-for-frontend-aesthetics) and the [frontend-design skill](https://github.com/anthropics/claude-code/blob/main/plugins/frontend-design/skills/frontend-design/SKILL.md) — prioritize high-impact motion moments, commit to the existing aesthetic with precision — as refinements **within** the site's wireframe/blueprint system (flat, hairline rails, no glows/gradients).

### Changes

- **Hero staggered entrance** — GSAP page-load reveal of eyebrow → headline → lede → CTAs (`power3.out`, 90ms stagger). Sections previously had no motion at all.
- **Scroll reveals** — new `useReveal` hook (IntersectionObserver, no ScrollTrigger per the lib's convention). Section headers and list/grid items rise in with per-batch stagger; the `data-reveal` attribute is removed after settling so it can't shadow `.cell` hover transitions.
- **Blueprint section indices** — eyebrows now read `01 / Experience` … `06 / Get in touch` for wireframe character.
- **Creative card imagery** — rests at 30% grayscale; hover restores full color with a slow 1.03 zoom.
- **Solid button hover** — was a literal no-op (same colors restated); now dims to `--accent-dim`.
- **Typography** — `text-wrap: balance` on display/h2, `text-wrap: pretty` on ledes.

### Accessibility

Hidden entrance states are gated behind `prefers-reduced-motion: no-preference`, so reduced-motion users (and non-JS readers) always see content immediately — verified in Chromium with `reducedMotion: 'reduce'` (all opacities 1, no animation).

### Verification

Ran the built site in headless Chromium (1440×900 and 390×844): hero stagger captured mid-flight and settled; `01 / Experience` renders with correct spacing; image hover computed `grayscale(0.3) → grayscale(0)` + `scale(1.03)`; button hover `rgb(242,243,245) → rgb(212,214,218)`; reveals fire after lazy-section mount. `npm run build` and `vitest` pass.

https://claude.ai/code/session_01EPnCE5L7JSeRNMJTjWGU2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPnCE5L7JSeRNMJTjWGU2z)_